### PR TITLE
Avoid creating new time on invalid time token

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -500,7 +500,7 @@ func tryParseTime(candidate string) (time.Time, bool) {
 		}
 	}
 
-	return time.Now(), false
+	return ret, false
 }
 
 func tryParseExactTime(candidate string, format string) (time.Time, bool) {
@@ -510,7 +510,7 @@ func tryParseExactTime(candidate string, format string) (time.Time, bool) {
 
 	ret, err = time.ParseInLocation(format, candidate, time.Local)
 	if err != nil {
-		return time.Now(), false
+		return ret, false
 	}
 
 	return ret, true


### PR DESCRIPTION
The parser attempts to parse each string token as time. In case of a non-time token, a time.Now() instance is created, which is immediately discarded. In a tight loop this unnecessary allocation can drastically slow down template parsing.

This PR simply returns time's empty value, which does not cause an allocation.